### PR TITLE
 [#187364691] ft-Admin should be able to disable an account for various reasons

### DIFF
--- a/src/components/StatusChangeModal.tsx
+++ b/src/components/StatusChangeModal.tsx
@@ -1,0 +1,156 @@
+import React, { useState, useRef } from "react";
+import { Dialog } from "@headlessui/react";
+import { FaChevronDown } from "react-icons/fa";
+import { IoCloseSharp } from "react-icons/io5";
+import axiosClient from "../hooks/AxiosInstance";
+import { toast } from "react-toastify";
+
+interface StatusChangeModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onStatusChange: (userId: number, newStatus: string) => void;
+  currentStatus: string;
+  user: { name: string; id: number };
+}
+
+interface CustomSelectProps {
+  value: string;
+  onChange: (value: string) => void;
+  options: string[];
+}
+
+const CustomSelect: React.FC<CustomSelectProps> = ({
+  value,
+  onChange,
+  options,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  return (
+    <div className="relative pb-5" ref={dropdownRef}>
+      <div
+        className="outline-none focus:outline-none shadow-[0_0_2px_rgba(0,0,0,0.9)] rounded p-2 w-full mt-2 flex justify-between items-center cursor-pointer"
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        {value.charAt(0).toUpperCase() + value.slice(1)}
+        <FaChevronDown
+          className={`transition-transform duration-300 ${
+            isOpen ? "transform rotate-180" : ""
+          }`}
+        />
+      </div>
+      {isOpen && (
+        <div className="absolute z-10 w-full mt-1 bg-white border border-gray-300 rounded shadow-lg">
+          {options.map((option) => (
+            <div
+              key={option}
+              className={`p-2 cursor-pointer hover:bg-customGreen hover:text-white transition-colors duration-200 ${
+                value === option ? "" : ""
+              }`}
+              onClick={() => {
+                onChange(option);
+                setIsOpen(false);
+              }}
+            >
+              {option.charAt(0).toUpperCase() + option.slice(1)}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const StatusChangeModal: React.FC<StatusChangeModalProps> = ({
+  isOpen,
+  onClose,
+  onStatusChange,
+  currentStatus,
+  user,
+}) => {
+  const [newStatus, setNewStatus] = useState(currentStatus);
+  const [description, setDescription] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+
+  const client = axiosClient();
+
+  const handleSave = async () => {
+    setIsLoading(true);
+    try {
+      await client.patch(`/users/${user.id}/status`, {
+        newStatus,
+        description,
+      });
+      toast(`User status updated to ${newStatus} successfully and email sent`);
+      onStatusChange(user.id, newStatus);
+      onClose();
+    } catch (err: any) {
+      toast(
+        err.response ? err.response.data.message : "Failed to update status",
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={isOpen}
+      onClose={onClose}
+      className="fixed z-10 inset-0 overflow-y-auto"
+    >
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="fixed inset-0 bg-black opacity-30" />
+        <div className="bg-white rounded-lg max-w-md mx-auto p-4 z-20 relative">
+          <div className="flex justify-center items-center">
+            <button
+              onClick={onClose}
+              className={`absolute top-0 right-0 p-2 rounded ${
+                isLoading
+                  ? "bg-gray-200 text-gray-500 cursor-not-allowed"
+                  : "bg-gray-200"
+              }`}
+              aria-label="Close"
+              disabled={isLoading}
+            >
+              <IoCloseSharp className="text-[20px]" />
+            </button>
+            <Dialog.Title className="text-lg font-bold pr-8">
+              Change Status of{" "}
+              <span className="text-customGreen font-semibold">
+                {user.name}
+              </span>
+            </Dialog.Title>
+          </div>
+          <CustomSelect
+            value={newStatus}
+            onChange={setNewStatus}
+            options={["active", "inactive"]}
+          />
+          {newStatus === "inactive" && (
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Reason for deactivation"
+              className="outline-none focus:outline-none shadow-[0_0_2px_rgba(0,0,0,0.9)] rounded p-2 w-full mt-2 text-xs"
+              rows={3}
+              disabled={isLoading}
+            />
+          )}
+          <div className="mt-4 flex justify-end">
+            <button
+              onClick={handleSave}
+              className="bg-black text-white p-2 rounded"
+              disabled={(newStatus === "inactive" && !description) || isLoading}
+            >
+              {isLoading ? "Loading..." : "Save"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </Dialog>
+  );
+};
+
+export default StatusChangeModal;

--- a/src/test/components/StatusCHangeModel.test.tsx
+++ b/src/test/components/StatusCHangeModel.test.tsx
@@ -1,0 +1,190 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import StatusChangeModal from "../../components/StatusChangeModal";
+import axiosClient from "../../hooks/AxiosInstance";
+import { toast } from "react-toastify";
+
+jest.mock("../../hooks/AxiosInstance", () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    patch: jest.fn(),
+  })),
+}));
+
+jest.mock("react-toastify", () => ({
+  toast: jest.fn(),
+}));
+
+describe("StatusChangeModal", () => {
+  const onCloseMock = jest.fn();
+  const onStatusChangeMock = jest.fn();
+  const user = { name: "John Doe", id: 1 };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("renders StatusChangeModal correctly", () => {
+    render(
+      <StatusChangeModal
+        isOpen={true}
+        onClose={onCloseMock}
+        onStatusChange={onStatusChangeMock}
+        currentStatus="active"
+        user={user}
+      />,
+    );
+
+    expect(screen.getByText(/Change Status of/)).toBeInTheDocument();
+    expect(screen.getByText(/John Doe/)).toBeInTheDocument();
+  });
+
+  test("can change status and save successfully", async () => {
+    const mockPatch = jest.fn().mockResolvedValue({});
+    (axiosClient as jest.Mock).mockReturnValue({
+      patch: mockPatch,
+    });
+
+    render(
+      <StatusChangeModal
+        isOpen={true}
+        onClose={onCloseMock}
+        onStatusChange={onStatusChangeMock}
+        currentStatus="active"
+        user={user}
+      />,
+    );
+
+    // Open status dropdown
+    fireEvent.click(screen.getByText("Active"));
+
+    // Select inactive status
+    fireEvent.click(screen.getByText("Inactive"));
+
+    // Enter description
+    fireEvent.change(screen.getByPlaceholderText("Reason for deactivation"), {
+      target: { value: "Reason for changing status" },
+    });
+
+    // Click save
+    fireEvent.click(screen.getByText("Save"));
+
+    await waitFor(() => {
+      expect(mockPatch).toHaveBeenCalledWith("/users/1/status", {
+        newStatus: "inactive",
+        description: "Reason for changing status",
+      });
+      expect(toast).toHaveBeenCalledWith(
+        "User status updated to inactive successfully and email sent",
+      );
+      expect(onStatusChangeMock).toHaveBeenCalledWith(1, "inactive");
+      expect(onCloseMock).toHaveBeenCalled();
+    });
+  });
+
+  test("handles error when saving status", async () => {
+    const mockPatch = jest
+      .fn()
+      .mockRejectedValue({
+        response: { data: { message: "Error updating status" } },
+      });
+    (axiosClient as jest.Mock).mockReturnValue({
+      patch: mockPatch,
+    });
+
+    render(
+      <StatusChangeModal
+        isOpen={true}
+        onClose={onCloseMock}
+        onStatusChange={onStatusChangeMock}
+        currentStatus="active"
+        user={user}
+      />,
+    );
+
+    // Open status dropdown and select inactive
+    fireEvent.click(screen.getByText("Active"));
+    fireEvent.click(screen.getByText("Inactive"));
+
+    // Enter description
+    fireEvent.change(screen.getByPlaceholderText("Reason for deactivation"), {
+      target: { value: "Reason for changing status" },
+    });
+
+    // Click save
+    fireEvent.click(screen.getByText("Save"));
+
+    await waitFor(() => {
+      expect(mockPatch).toHaveBeenCalled();
+      expect(toast).toHaveBeenCalledWith("Error updating status");
+      expect(onStatusChangeMock).not.toHaveBeenCalled();
+      expect(onCloseMock).not.toHaveBeenCalled();
+    });
+  });
+
+  test("displays loading state while saving", async () => {
+    const mockPatch = jest
+      .fn()
+      .mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 100)),
+      );
+    (axiosClient as jest.Mock).mockReturnValue({
+      patch: mockPatch,
+    });
+
+    render(
+      <StatusChangeModal
+        isOpen={true}
+        onClose={onCloseMock}
+        onStatusChange={onStatusChangeMock}
+        currentStatus="active"
+        user={user}
+      />,
+    );
+
+    // Open status dropdown and select inactive
+    fireEvent.click(screen.getByText("Active"));
+    fireEvent.click(screen.getByText("Inactive"));
+
+    // Enter description
+    fireEvent.change(screen.getByPlaceholderText("Reason for deactivation"), {
+      target: { value: "Reason for changing status" },
+    });
+
+    // Click save
+    fireEvent.click(screen.getByText("Save"));
+
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
+    });
+  });
+
+  test("disables save button if description is empty for inactive status", () => {
+    render(
+      <StatusChangeModal
+        isOpen={true}
+        onClose={onCloseMock}
+        onStatusChange={onStatusChangeMock}
+        currentStatus="active"
+        user={user}
+      />,
+    );
+
+    // Open status dropdown
+    fireEvent.click(screen.getByText("Active"));
+
+    // Select inactive status
+    fireEvent.click(screen.getByText("Inactive"));
+
+    expect(screen.getByText("Save")).toBeDisabled();
+
+    // Enter description
+    fireEvent.change(screen.getByPlaceholderText("Reason for deactivation"), {
+      target: { value: "Reason" },
+    });
+
+    expect(screen.getByText("Save")).not.toBeDisabled();
+  });
+});

--- a/src/views/ForgotPassword.tsx
+++ b/src/views/ForgotPassword.tsx
@@ -93,13 +93,13 @@ const ForgotPassword: React.FC = () => {
           </Formik>
           <p className="login-register text-xs mb-3 text-center">
             Already have an account.{" "}
-            <Link to="/login" className="text-links hover:text-links-hover">
+            <Link to="/login" className="text-customBlue hover:text-customBlue-hover">
               Login
             </Link>
           </p>
           <p className="login-register text-xs text-center">
             Don't have an account.{" "}
-            <Link to="/register" className="text-links hover:text-links-hover">
+            <Link to="/register" className="text-customBlue hover:text-customBlue-hover">
               Create One
             </Link>
           </p>

--- a/src/views/admin/UsersTable.tsx
+++ b/src/views/admin/UsersTable.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useState } from "react";
-import { FaEdit } from "react-icons/fa";
+import { CiEdit } from "react-icons/ci";
 import RoleChangeModal from "../../components/RoleChange";
+import StatusChangeModal from "../../components/StatusChangeModal";
 import axiosClient from "../../hooks/AxiosInstance";
-import { toast } from "react-toastify";
+import { ToastContainer, toast } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
 
 interface User {
   id: number;
@@ -19,6 +21,8 @@ const UsersTable = () => {
   const [selectedUser, setSelectedUser] = useState<User | null>(null);
   const [newRole, setNewRole] = useState<string>("");
   const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isStatusModalOpen, setIsStatusModalOpen] = useState(false);
+
   const client = axiosClient();
   const notify = (message: string) => toast(message);
 
@@ -62,6 +66,16 @@ const UsersTable = () => {
     setSelectedUser(null);
   };
 
+  const openStatusModal = (user: User) => {
+    setSelectedUser(user);
+    setIsStatusModalOpen(true);
+  };
+
+  const closeStatusModal = () => {
+    setSelectedUser(null);
+    setIsStatusModalOpen(false);
+  };
+
   const saveRole = async (newRole: string) => {
     if (selectedUser) {
       setIsLoading(true);
@@ -82,6 +96,14 @@ const UsersTable = () => {
         setSelectedUser(null);
       }
     }
+  };
+
+  const handleStatusChange = (userId: number, newStatus: string) => {
+    setUsers((prevUsers) =>
+      prevUsers.map((user) =>
+        user.id === userId ? { ...user, status: newStatus } : user,
+      ),
+    );
   };
 
   return (
@@ -145,13 +167,24 @@ const UsersTable = () => {
                     </span>
                   </td>
                   <td className="py-2 px-4 border-b border-gray-200 text-left">
-                    <button
-                      aria-label="edit"
-                      className="bg-view_more text-white px-2 py-1 rounded flex items-center justify-center"
-                      onClick={() => openModal(user)}
-                    >
-                      <FaEdit className="text-lg" />
-                    </button>
+                    <div className="flex space-x-2 max-xs:block max-xs:space-y-2 max-xs:space-x-0">
+                      <button
+                        aria-label="edit"
+                        className="bg-customBlueBg text-customBlue px-5 max-xs:px-2 rounded-full flex items-center justify-center"
+                        onClick={() => openModal(user)}
+                      >
+                        <CiEdit className="text-lg" />
+                        role
+                      </button>
+                      <button
+                        aria-label="change status"
+                        className="bg-customGreenBg text-customGreen px-3  max-xs:px-0 rounded-full flex items-center justify-center"
+                        onClick={() => openStatusModal(user)}
+                      >
+                        <CiEdit className="text-lg" />
+                        status
+                      </button>
+                    </div>
                   </td>
                 </tr>
               ))
@@ -185,6 +218,16 @@ const UsersTable = () => {
           setNewRole={setNewRole}
         />
       )}
+      {selectedUser && isStatusModalOpen && (
+        <StatusChangeModal
+          isOpen={isStatusModalOpen}
+          onClose={closeStatusModal}
+          onStatusChange={handleStatusChange}
+          currentStatus={selectedUser.status}
+          user={{ name: selectedUser.username, id: selectedUser.id }}
+        />
+      )}
+      <ToastContainer />
     </div>
   );
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,8 +15,12 @@ export default {
         gray_100: "#A8A8A8",
         on_black: "#FFFFFF",
         "main-black-color": "#262626",
-        links: "#1976D2",
-        "links-hover": "#0563c1",
+        "customBlue-hover": "#0563c1",
+        customBlue: "#1976D2",
+        customBlueBg: "rgba(25, 118, 210, 0.1)", // 30% opacity
+        customGreen: "#4CAF50",
+        customGreenBg: "rgba(76, 175, 80, 0.1)",
+        customRed: "#FF6347",
         dashColor: "#F3F2F0",
         view_more: "#4D98E2",
         view_more_text: "#1976D2",
@@ -43,6 +47,7 @@ export default {
         bigphone: "650px",
         tablet: "860px",
         laptop: "1200px",
+        xs: "510px",
       },
       height: {
         "50vh": "50vh",
@@ -56,5 +61,13 @@ export default {
       },
     },
   },
-  plugins: [],
+  plugins: [
+    function ({ addUtilities }) {
+      addUtilities({
+        ".outline-none": {
+          outline: "0",
+        },
+      });
+    },
+  ],
 };


### PR DESCRIPTION
**What does this PR do?**
This PR introduces a new feature that allows administrators to disable user accounts for various reasons, such as fraud, abuse, malicious use, or violation of terms of service. The motivation for adding this feature is to enhance the security and integrity of the application by providing administrators with the necessary tools to manage user accounts and take action against those who violate the platform's terms of service.

**Type of change**
 New feature (non-breaking change which adds functionality)

**How Has This Been Tested?**
Describe the testing process for this feature:

Unit Tests: Created and executed unit tests to ensure the functionality works as expected.
Integration Tests: Verified that the feature integrates well with the existing codebase and does not introduce any regressions.
Manual Testing: Manually tested the feature by simulating different scenarios where an admin disables user accounts for various reasons and checked if the accounts were successfully disabled and appropriate emails were sent.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## What are the relevant pivotal tracker/Trello stories?

## Screenshots (if appropriate)

